### PR TITLE
Fix output whitespace, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,30 @@ This theme is based on a similar theme by kimamula:
 I only developed this one because the original seems to be a bit out of date, and because 
 I want to customize it for my own needs.
 
+## Installation
+```
+npm install --save-dev typedoc-md-theme
+```
+
 ## Usage
 ```
-npm install --save-dev typedoc
-bin/typedoc --options typedoc.json --source src
+node_modules/typedoc-md-theme/bin/typedoc --options typedoc.json --source src
 ```
 Note that `bin/typedoc` its not the typedoc cli itself, but a node script wrapper that leverages the 
 typedoc api. This is a workaround for modifying typedoc's theming code in order to get correct md
 extensions and link urls.
+
+## Sample typedoc.json
+```
+{
+  "theme": "node_modules/typedoc-md-theme/bin",
+  "mode": "modules",
+  "moduleResolution": "node",
+  "tsconfig": "tsconfig.json",
+  "includeDeclarations": true,
+  "ignoreCompilerErrors": true,
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "out": "docs/markdown"
+}
+```

--- a/bin/typedoc
+++ b/bin/typedoc
@@ -52,6 +52,11 @@ console.log("~typedoc~ using ts sources from: " + srcPath);
 console.log("~typedoc~ options: " + JSON.stringify(options));
 var app = new typedoc.Application(options);
 
+// Remove unwanted plugins
+app.renderer.removeComponent('assets');
+app.renderer.removeComponent('javascript-index');
+app.renderer.removeComponent('pretty-print');
+
 // Register handlebars helpers.
 handlebars.registerHelper('newLine', function () { return '\n'; });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typedoc-md-theme",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple markdown theme for typedoc.",
   "main": "bin/typedoc",
   "scripts": {


### PR DESCRIPTION
I was having some problems with the output incorrectly nesting lists and stripping line breaks. I checked the original markdown theme and it was removing a few plugins, so I did the same.