### PR TITLE
fixed registering the newLine handlebars helper

### DIFF
--- a/bin/helpers/newLine.js
+++ b/bin/helpers/newLine.js
@@ -1,0 +1,5 @@
+"use strict";
+function newLine() {
+    return '\n';
+}
+exports.newLine = newLine;

--- a/bin/typedoc
+++ b/bin/typedoc
@@ -57,9 +57,6 @@ app.renderer.removeComponent('assets');
 app.renderer.removeComponent('javascript-index');
 app.renderer.removeComponent('pretty-print');
 
-// Register handlebars helpers.
-handlebars.registerHelper('newLine', function () { return '\n'; });
-
 // Tweak typedoc in order to:
 // 1. Output files with .md extensions
 // 2. Produce internal links with .md extensions


### PR DESCRIPTION
using `Handlebars.registerHelper` in `bin/typedoc` doesn't work, because typedoc looks for helpers in a different way.
typedoc scans the plugin directory for a helpers folder, where a js file should be placed which exports the helper function.
This should fixed the newLine issue mentioned in #2 